### PR TITLE
Filesystem mocks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,6 +44,7 @@
 		"@typescript-eslint/no-empty-interface": "off",
 		"@typescript-eslint/require-await": "warn",
 		"@typescript-eslint/no-inferrable-types": "off",
+		"@typescript-eslint/no-invalid-void-type": ["warn", { "allowAsThisParameter": true }],
 		"@typescript-eslint/no-unused-vars": "warn",
 		"@typescript-eslint/explicit-member-accessibility": [
 			"error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2023-09-15
+
+### Changed
+
+- Reorganized filesystem APIs so they're easier to mock on different test platforms.
+
 ## [1.1.1] - 2023-09-11
 
 ### Fixed
@@ -34,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Load and view notes and annotations from https://www.churchofjesuschrist.org.
 - Navigation in CLI by arrow keys.
 
+[1.1.2]: https://github.com/AverageHelper/gospel-library-export/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/AverageHelper/gospel-library-export/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/AverageHelper/gospel-library-export/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/AverageHelper/gospel-library-export/releases/tag/v1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gospel-library-export",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gospel-library-export",
-			"version": "1.1.1",
+			"version": "1.1.2",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"date-fns": "2.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gospel-library-export",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"private": true,
 	"description": "A tool for exporting and viewing notes and marks from churchofjesuschrist.org.",
 	"scripts": {

--- a/src/helpers/archives.test.ts
+++ b/src/helpers/archives.test.ts
@@ -1,25 +1,23 @@
-import type { Dirent } from "node:fs";
 import { dataDir, findArchives } from "./archives.js";
 import { resolve as resolvePath } from "node:path";
 
-vi.mock("../ui/index.js");
-
 import { loader } from "../ui/index.js";
+const mockLoaderInfo = vi.spyOn(loader, "info");
+const mockLoaderStart = vi.spyOn(loader, "start");
+const mockLoaderFail = vi.spyOn(loader, "fail");
+const mockLoaderSucceed = vi.spyOn(loader, "succeed");
 
-/* eslint-disable @typescript-eslint/unbound-method */
-const mockLoaderInfo = loader.info as Mock<typeof loader.info>;
-const mockLoaderStart = loader.start as Mock<typeof loader.start>;
-const mockLoaderFail = loader.fail as Mock<typeof loader.fail>;
-const mockLoaderSucceed = loader.succeed as Mock<typeof loader.succeed>;
-/* eslint-enable @typescript-eslint/unbound-method */
+import type { Dirent, FilesystemProxy } from "../helpers/fs.js";
+const testFs: FilesystemProxy = {
+	mkdir: vi.fn(() => Promise.resolve(undefined)),
+	readdir: vi.fn(() => Promise.resolve([])),
+	readFile: vi.fn(() => Promise.reject(new Error("ENOENT"))),
+	writeFile: vi.fn(() => Promise.resolve(undefined))
+};
 
-vi.mock("node:fs/promises");
-
-import { mkdir, readdir, readFile } from "node:fs/promises";
-
-const mockMkdir = mkdir as Mock<typeof mkdir>;
-const mockReaddir = readdir as unknown as Mock<typeof readdir>;
-const mockReadFile = readFile as Mock<typeof readFile>;
+const mockMkdir = testFs.mkdir as Mock<typeof testFs.mkdir>;
+const mockReaddir = testFs.readdir as Mock<typeof testFs.readdir>;
+const mockReadFile = testFs.readFile as Mock<typeof testFs.readFile>;
 
 describe("Local Archives", () => {
 	const testDirEnt: Dirent = {
@@ -48,7 +46,7 @@ describe("Local Archives", () => {
 		const error = new Error("something went wrong");
 		mockReaddir.mockRejectedValue(error);
 
-		await expect(findArchives()).rejects.toBe(error);
+		await expect(findArchives(testFs)).rejects.toBe(error);
 
 		expect(mockMkdir).not.toHaveBeenCalled();
 		expect(mockReadFile).not.toHaveBeenCalled();
@@ -56,7 +54,7 @@ describe("Local Archives", () => {
 
 	test("creates a data directory if it doesn't already exist", async () => {
 		// Returns empty map
-		await expect(findArchives()).resolves.toMatchObject(new Map());
+		await expect(findArchives(testFs)).resolves.toMatchObject(new Map());
 
 		expect(mockReaddir).toHaveBeenCalledExactlyOnceWith(dataDir, {
 			encoding: "utf-8",
@@ -83,7 +81,7 @@ describe("Local Archives", () => {
 	test("returns an empty map if the data directory is empty", async () => {
 		mockReaddir.mockResolvedValue([]);
 
-		await expect(findArchives()).resolves.toMatchObject(new Map());
+		await expect(findArchives(testFs)).resolves.toMatchObject(new Map());
 
 		expect(mockReaddir).toHaveBeenCalledExactlyOnceWith(dataDir, {
 			encoding: "utf-8",
@@ -110,7 +108,7 @@ describe("Local Archives", () => {
 		mockReadFile.mockRejectedValue(new Error("something went wrong")); // file unreadable for some reason
 		const filePath = resolvePath(testDirEnt.path, testDirEnt.name);
 
-		await expect(findArchives()).resolves.toMatchObject(new Map());
+		await expect(findArchives(testFs)).resolves.toMatchObject(new Map());
 
 		expect(mockReaddir).toHaveBeenCalledExactlyOnceWith(dataDir, {
 			encoding: "utf-8",
@@ -140,7 +138,7 @@ describe("Local Archives", () => {
 		mockReadFile.mockResolvedValue("Lorem Ipsum"); // not valid JSON
 		const filePath = resolvePath(testDirEnt.path, testDirEnt.name);
 
-		await expect(findArchives()).resolves.toMatchObject(new Map());
+		await expect(findArchives(testFs)).resolves.toMatchObject(new Map());
 
 		// Directory doesn't get remade
 		expect(mockMkdir).not.toHaveBeenCalled();
@@ -164,7 +162,7 @@ describe("Local Archives", () => {
 		mockReadFile.mockResolvedValue(JSON.stringify({})); // not a valid archive
 		const filePath = resolvePath(testDirEnt.path, testDirEnt.name);
 
-		await expect(findArchives()).resolves.toMatchObject(new Map());
+		await expect(findArchives(testFs)).resolves.toMatchObject(new Map());
 
 		// Directory doesn't get remade
 		expect(mockMkdir).not.toHaveBeenCalled();
@@ -188,7 +186,7 @@ describe("Local Archives", () => {
 		mockReadFile.mockResolvedValue(JSON.stringify([])); // empty archive
 		const filePath = resolvePath(testDirEnt.path, testDirEnt.name);
 
-		const result = await findArchives();
+		const result = await findArchives(testFs);
 		expect(result).toBeInstanceOf(Map);
 		expect(result.size).toBe(1);
 		expect(result.get(filePath)).toMatchObject([]);

--- a/src/helpers/archives.ts
+++ b/src/helpers/archives.ts
@@ -1,9 +1,8 @@
 import type { Annotation } from "../structs/index.js";
-import type { Dirent } from "node:fs";
+import type { Dirent, FilesystemProxy } from "../helpers/fs.js";
 import { annotation } from "../structs/annotations.js";
 import { array, assert } from "superstruct";
 import { loader } from "../ui/index.js";
-import { mkdir, readdir, readFile } from "node:fs/promises";
 import { resolve as resolvePath } from "node:path";
 import { URL } from "node:url";
 
@@ -12,13 +11,13 @@ export const dataDir = new URL(`file:${resolvePath(process.cwd(), "data")}`);
 /**
  * Searches the `./data` directory for viable annotations archives.
  */
-export async function findArchives(): Promise<Map<string, Array<Annotation>>> {
+export async function findArchives(fs: FilesystemProxy): Promise<Map<string, Array<Annotation>>> {
 	// Check `./data` directory for archives...
 	const archives = new Map<string, Array<Annotation>>();
 
 	let dir: ReadonlyArray<Dirent> | undefined;
 	try {
-		dir = await readdir(dataDir, {
+		dir = await fs.readdir(dataDir, {
 			encoding: "utf-8",
 			recursive: false,
 			withFileTypes: true
@@ -28,7 +27,7 @@ export async function findArchives(): Promise<Map<string, Array<Annotation>>> {
 		if (!(error instanceof Error) || !error.message.includes("ENOENT")) throw error;
 
 		// Create our `/data` directory since it doesn't already exist
-		await mkdir(dataDir);
+		await fs.mkdir(dataDir);
 		loader.info(`Created archive directory at '${dataDir.pathname}'`);
 	}
 
@@ -38,7 +37,7 @@ export async function findArchives(): Promise<Map<string, Array<Annotation>>> {
 		const filePath = resolvePath(entry.path, entry.name);
 
 		try {
-			const contents = await readFile(filePath, { encoding: "utf-8" });
+			const contents = await fs.readFile(filePath, "utf-8");
 
 			// See if data is a valid annotation archive
 			const data = JSON.parse(contents) as unknown;

--- a/src/helpers/archives.ts
+++ b/src/helpers/archives.ts
@@ -3,10 +3,10 @@ import type { Dirent, FilesystemProxy } from "../helpers/fs.js";
 import { annotation } from "../structs/annotations.js";
 import { array, assert } from "superstruct";
 import { loader } from "../ui/index.js";
+import { pathToFileURL } from "node:url";
 import { resolve as resolvePath } from "node:path";
-import { URL } from "node:url";
 
-export const dataDir = new URL(`file:${resolvePath(process.cwd(), "data")}`);
+export const dataDir = pathToFileURL(resolvePath("data"));
 
 /**
  * Searches the `./data` directory for viable annotations archives.

--- a/src/helpers/fs.ts
+++ b/src/helpers/fs.ts
@@ -1,0 +1,24 @@
+import type { Dirent } from "node:fs";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+
+export const fs = {
+	mkdir,
+	async readdir(
+		this: void,
+		path: PathLike,
+		options: {
+			encoding?: BufferEncoding | null | undefined;
+			withFileTypes: true;
+			recursive?: boolean | undefined;
+		}
+	): Promise<Array<Dirent>> {
+		return await readdir(path, options);
+	},
+	async readFile(this: void, path: PathOrFileDescriptor, options: BufferEncoding): Promise<string> {
+		return await readFile(path, options);
+	},
+	writeFile
+} as const;
+
+export type FilesystemProxy = typeof fs;
+export type { Dirent };

--- a/src/helpers/fs.ts
+++ b/src/helpers/fs.ts
@@ -1,8 +1,11 @@
-import type { Dirent } from "node:fs";
+import type { Dirent, PathLike } from "node:fs";
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 
 export const fs = {
-	mkdir,
+	async mkdir(this: void, path: PathLike): Promise<void> {
+		return await mkdir(path);
+	},
+
 	async readdir(
 		this: void,
 		path: PathLike,
@@ -14,10 +17,19 @@ export const fs = {
 	): Promise<Array<Dirent>> {
 		return await readdir(path, options);
 	},
-	async readFile(this: void, path: PathOrFileDescriptor, options: BufferEncoding): Promise<string> {
+
+	async readFile(this: void, path: PathLike, options: BufferEncoding): Promise<string> {
 		return await readFile(path, options);
 	},
-	writeFile
+
+	async writeFile(
+		this: void,
+		path: PathLike,
+		data: string,
+		options: { encoding?: BufferEncoding | null | undefined }
+	) {
+		return await writeFile(path, data, options);
+	}
 } as const;
 
 export type FilesystemProxy = typeof fs;

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import inquirer from "inquirer";
 import { Dim, Reset } from "./helpers/consoleColors.js";
 import { downloadAll, selectAndViewArchive, viewAnnotationData } from "./ui/index.js";
 import { findArchives } from "./helpers/archives.js";
+import { fs } from "./helpers/fs.js";
 import { header } from "./helpers/formatting.js";
 import { UnreachableCaseError } from "./helpers/UnreachableCaseError.js";
 
@@ -14,7 +15,7 @@ console.info(header("Gospel Library Notes Inspector"));
 while (true) {
 	type Action = "download" | "online" | "offline";
 
-	const archives = await findArchives();
+	const archives = await findArchives(fs);
 
 	const choices = [
 		{
@@ -46,7 +47,7 @@ while (true) {
 	switch (action) {
 		case "download":
 			// Download prod data to `./data` folder, then exit
-			await downloadAll();
+			await downloadAll(fs);
 			break;
 
 		case "online":

--- a/src/ui/downloadAll.ts
+++ b/src/ui/downloadAll.ts
@@ -6,6 +6,7 @@ import { annotation } from "../structs/annotations.js";
 import { array, assert } from "superstruct";
 import { dataDir } from "../helpers/archives.js";
 import { loader } from "./loader.js";
+import { pathToFileURL } from "node:url";
 import { requestCookie } from "./requestCookie.js";
 import { resolve as resolvePath } from "node:path";
 
@@ -49,7 +50,7 @@ export async function downloadAll(fs: FilesystemProxy): Promise<void> {
 	const now = new Date();
 	const fileName = `archive ${format(now, "uuuu-MM-dd HH-mm-ss.SSS X")}`;
 	const fileExtension = "json";
-	const fileUrl = new URL(`file:${resolvePath(dataDir.pathname, `${fileName}.${fileExtension}`)}`);
+	const fileUrl = pathToFileURL(resolvePath(dataDir.pathname, `${fileName}.${fileExtension}`));
 
 	const fileData = JSON.stringify(annotations);
 	await fs.writeFile(fileUrl, fileData, { encoding: "utf-8" });

--- a/src/ui/downloadAll.ts
+++ b/src/ui/downloadAll.ts
@@ -1,4 +1,5 @@
 import type { Annotation } from "../structs/annotations.js";
+import type { FilesystemProxy } from "../helpers/fs.js";
 import format from "date-fns/format/index.js";
 import { allAnnotations } from "../api.js";
 import { annotation } from "../structs/annotations.js";
@@ -7,13 +8,12 @@ import { dataDir } from "../helpers/archives.js";
 import { loader } from "./loader.js";
 import { requestCookie } from "./requestCookie.js";
 import { resolve as resolvePath } from "node:path";
-import { writeFile } from "node:fs/promises";
 
 /**
  * A UI loop to download all of a user's annotations to a local
  * file for later offline viewing.
  */
-export async function downloadAll(): Promise<void> {
+export async function downloadAll(fs: FilesystemProxy): Promise<void> {
 	const PAGE_SIZE = 1000; // in testing, this is the page size given when page size is omitted
 
 	await requestCookie(true);
@@ -52,7 +52,7 @@ export async function downloadAll(): Promise<void> {
 	const fileUrl = new URL(`file:${resolvePath(dataDir.pathname, `${fileName}.${fileExtension}`)}`);
 
 	const fileData = JSON.stringify(annotations);
-	await writeFile(fileUrl, fileData, { encoding: "utf-8" });
+	await fs.writeFile(fileUrl, fileData, { encoding: "utf-8" });
 
 	loader.succeed(
 		`Wrote ${annotations.length} annotations to '${decodeURIComponent(fileUrl.pathname)}'`


### PR DESCRIPTION
While working on Bun support, we ran into several issues that made mocking difficult.

This PR reduces our reliance on test harness magic to mock module imports, instead moving the filesystem API dependency to a function parameter, to be replaced at call time.

Once https://github.com/oven-sh/bun/issues/5394 is resolved, we can move the function parameter back to an import if we so choose.