### PR TITLE
chore: Useless commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "1.1.4",
 	"private": true,
 	"description": "A tool for exporting and viewing notes and marks from churchofjesuschrist.org.",
+
 	"scripts": {
 		"prebuild": "npm run export-version && npm run lint",
 		"build": "./node_modules/.bin/tsc -p tsconfig.prod.json",


### PR DESCRIPTION
Test new PR auto-close.

Previously, the Forgejo Runner would pick up the GitHub auto-close script and run it, then predictably fail (because that's Forgejo, not GitHub). This change has effectively prevented the script from running on Forgejo. Now testing that the script _does_ still run on GitHub.